### PR TITLE
fix simpleSearch bug when term starts with an uppercase character

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -24,7 +24,8 @@ function search (term, n = 4) {
 }
 
 function simpleSearch (term) {
-  return request(`https://v2.sg.media-imdb.com/suggests/${term[0]}/${term}.json`).then((data) => {
+  let prefix = term[0].toLowerCase();
+  return request(`https://v2.sg.media-imdb.com/suggests/${prefix}/${term}.json`).then((data) => {
     let termWithUnderscores = term.split(' ').join('_')
     data = data.split(`imdb$${termWithUnderscores}(`)
     let re = data[1].split('')


### PR DESCRIPTION
If the term started with an uppercase character (eg. The Flash), the resulting url "https://v2.sg.media-imdb.com/suggests/T/The%20Flash.json" would be invalid (as T is an incorrect prefix, t however is the correct one => "https://v2.sg.media-imdb.com/suggests/t/The%20Flash.json").